### PR TITLE
#2749 Fix file_types_order flagging extensions

### DIFF
--- a/Rules.md
+++ b/Rules.md
@@ -7812,6 +7812,13 @@ extension TestViewController: UITableViewDataSource {
 }
 ```
 
+```swift
+// Only extensions
+extension Foo {}
+extension Bar {
+}
+```
+
 </details>
 <details>
 <summary>Triggering Examples</summary>

--- a/Source/SwiftLintFramework/Rules/Style/FileTypesOrderRule.swift
+++ b/Source/SwiftLintFramework/Rules/Style/FileTypesOrderRule.swift
@@ -47,6 +47,9 @@ public struct FileTypesOrderRule: ConfigurationProviderRule, OptInRule {
             return lhs.offset < rhs.offset
         }
 
+        guard orderedFileTypeOffsets.map({ $0.fileType }).contains(.mainType) ||
+              !configuration.order.flatMap({ $0 }).contains(.mainType) else { return [] }
+
         var violations =  [StyleViolation]()
 
         var lastMatchingIndex = -1

--- a/Source/SwiftLintFramework/Rules/Style/FileTypesOrderRuleExamples.swift
+++ b/Source/SwiftLintFramework/Rules/Style/FileTypesOrderRuleExamples.swift
@@ -123,7 +123,15 @@ internal struct FileTypesOrderRuleExamples {
         """
     ]
 
-    static let nonTriggeringExamples = [FileTypesOrderRuleExamples.defaultOrderParts.joined(separator: "\n\n")]
+    static let nonTriggeringExamples = [
+        FileTypesOrderRuleExamples.defaultOrderParts.joined(separator: "\n\n"),
+        """
+        // Only extensions
+        extension Foo {}
+        extension Bar {
+        }
+        """
+    ]
 
     static let triggeringExamples = [
         """


### PR DESCRIPTION
An attempt to prevent files only containing extensions being flagged by the file_types_order rule